### PR TITLE
51 integrate fixationgrower read in for trials table

### DIFF
--- a/code/training_performance/dj_exploratory_notebooks/fixationgrower_read_in.ipynb
+++ b/code/training_performance/dj_exploratory_notebooks/fixationgrower_read_in.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FixationGrower Read In \n",
+    "\n",
+    "**Goal**: Make any updates to `create_trials_df.py` to allow for read-in of `FixationGrower` protocol\n",
+    "\n",
+    "**Context**: trials table import was all created for DMS2 protocol and may need to be adjusted for new columns or columns that no longer exist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2024-07-16 11:51:41,492][INFO]: Connecting jbreda@bdata00.pni.princeton.edu:3306\n",
+      "[2024-07-16 11:51:42,744][INFO]: Connected jbreda@bdata00.pni.princeton.edu:3306\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../\")\n",
+    "\n",
+    "from create_trials_df import *\n",
+    "\n",
+    "import pandas as pd\n",
+    "import datetime\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fetched 7 sessions for R010 between 2024-07-09 and 2024-07-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "animal_id = [\"R010\"]\n",
+    "date_min = \"2024-07-09\"\n",
+    "\n",
+    "# Create a dataframe with all the trials\n",
+    "trials_df = create_trials_df_from_dj(animal_id, date_min)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bl_dj_310",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Closes #51. 

Minimal necessary changes to read in data from `FixationGrower` as a trials table. Added in tracking of a `protocol` variable. Note this code allows for both DMS2 and FixationGrower data to exist in one single dataframe (with Nans for the columns that don't exists in both). See issue for more details on changes & rationale